### PR TITLE
Add note about pre-1.4 Elixir versions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the [online documentation](https://hexdocs.pm/nimble_csv) for more informati
     end
     ```
 
-  2. Ensure `nimble_csv` is started before your application:
+  2. If using Elixir < 1.4, ensure `nimble_csv` is started before your application:
 
     ```elixir
     def application do


### PR DESCRIPTION
No need to add application on newer versions of Elixir.