### PR TITLE
Fix typo in documentation: header -> headers

### DIFF
--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -145,7 +145,7 @@ defmodule NimbleCSV do
 
   ## Options
 
-    * `:header` - when `false`, no longer discard the first row. Defaults to `true`.
+    * `:headers` - when `false`, no longer discard the first row. Defaults to `true`.
 
   """
   @callback parse_string(binary(), opts :: keyword()) :: [[binary()]]


### PR DESCRIPTION
I missed one! Sorry!