### PR TITLE
Accept an array of separators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ matrix:
       otp_release: 18.3
     - elixir: 1.5.2
       otp_release: 20.1
+    - elixir: 1.6.2
+      otp_release: 21.0
+    - elixir: 1.7.2
+      otp_release: 21.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ matrix:
     - elixir: 1.5.2
       otp_release: 20.1
     - elixir: 1.6.2
-      otp_release: 21.0
+      otp_release: 20.1
     - elixir: 1.7.2
       otp_release: 21.0

--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -165,10 +165,13 @@ defmodule NimbleCSV do
 
   The following options control parsing:
 
-    * `:escape`- the CSV escape character, defaults to `"\""`
-    * `:separator`- the CSV separator character, defaults to `","`
+    * `:escape`- the CSV escape, defaults to `"\""`
+    * `:separator`- the CSV separators, defaults to `","`. It can be
+      a string or a list of strings. If a list is given, the first entry
+      is used for dumping (see below)
     * `:newlines` - the list of entries to be considered newlines
-      when parsing, defaults to `["\r\n", "\n"]` (note the order matters)
+      when parsing, defaults to `["\r\n", "\n"]` (note they are attempted
+      in order, so the order matters)
 
   The following options control dumping:
 
@@ -194,8 +197,8 @@ defmodule NimbleCSV do
       @moduledoc Keyword.get(options, :moduledoc)
       @escape Keyword.get(options, :escape, "\"")
       @separator (case Keyword.get(options, :separator, ",") do
-                  many when is_list(many) -> many
-                  one when is_binary(one) -> [one]
+                    many when is_list(many) -> many
+                    one when is_binary(one) -> [one]
                   end)
       @line_separator Keyword.get(options, :line_separator, "\n")
       @newlines Keyword.get(options, :newlines, ["\r\n", "\n"])

--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -193,10 +193,13 @@ defmodule NimbleCSV do
     defmodule module do
       @moduledoc Keyword.get(options, :moduledoc)
       @escape Keyword.get(options, :escape, "\"")
-      @separator Keyword.get(options, :separator, ",")
+      @separator (case Keyword.get(options, :separator, ",") do
+                  many when is_list(many) -> many
+                  one when is_binary(one) -> [one]
+                  end)
       @line_separator Keyword.get(options, :line_separator, "\n")
       @newlines Keyword.get(options, :newlines, ["\r\n", "\n"])
-      @reserved Keyword.get(options, :reserved, [@escape, @separator, @line_separator])
+      @reserved Keyword.get(options, :reserved, [@escape | @separator] ++ [@line_separator])
 
       @behaviour NimbleCSV
 
@@ -288,6 +291,24 @@ defmodule NimbleCSV do
         end
       end
 
+      @separator_clauses Enum.flat_map(@separator, fn sep ->
+          quote do
+            <<prefix::size(var!(pos))-binary, unquote(sep), @escape, rest::binary>> ->
+              escape(rest, "", var!(row) ++ :binary.split(prefix, var!(separator), [:global]), var!(state), var!(separator), var!(escape))
+          end
+        end) ++ quote(do: (
+          _ ->
+            raise(ParseError, "unexpected escape character #{@escape} in #{inspect var!(line)}")
+        ))
+
+      defmacrop separator_case() do
+        quote do
+          case var!(line) do
+          unquote(@separator_clauses)
+          end
+        end
+      end
+
       defp separator(line, row, state, separator, escape) do
         case :binary.match(line, escape) do
           {0, _} ->
@@ -296,12 +317,7 @@ defmodule NimbleCSV do
 
           {pos, _} ->
             pos = pos - 1
-            case line do
-              <<prefix::size(pos)-binary, @separator, @escape, rest::binary>> ->
-                escape(rest, "", row ++ :binary.split(prefix, separator, [:global]), state, separator, escape)
-              _ ->
-                raise ParseError, "unexpected escape character #{@escape} in #{inspect line}"
-            end
+            separator_case()
 
           :nomatch ->
             pruned = newlines_separator!()
@@ -314,11 +330,15 @@ defmodule NimbleCSV do
           quote do
             <<prefix::size(offset)-binary, @escape, @escape, rest::binary>> ->
               escape(rest, var!(entry) <> prefix <> <<@escape>>,
-                     var!(row), var!(state), var!(separator), var!(escape))
-            <<prefix::size(offset)-binary, @escape, @separator, rest::binary>> ->
-              separator(rest, var!(row) ++ [var!(entry) <> prefix],
-                        var!(state), var!(separator), var!(escape))
-          end
+                    var!(row), var!(state), var!(separator), var!(escape))
+          end ++
+          Enum.map(@separator, fn sep ->
+            quote do
+              <<prefix::size(offset)-binary, @escape, unquote(sep), rest::binary>> ->
+                separator(rest, var!(row) ++ [var!(entry) <> prefix],
+                          var!(state), var!(separator), var!(escape))
+            end |> hd()
+          end)
 
         newlines_clauses =
           for newline <- @newlines do
@@ -370,8 +390,8 @@ defmodule NimbleCSV do
       end)
 
       @separator_minimum (case @separator do
-        <<x>> -> x
-        x -> x
+        [<<x>> | _] -> x
+        [x | _] -> x
       end)
 
       @line_separator_minimum (case @line_separator do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule NimbleCSV.Mixfile do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.0"
 
   def project do
     [app: :nimble_csv,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule NimbleCSV.Mixfile do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
 
   def project do
     [app: :nimble_csv,

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -204,85 +204,87 @@ defmodule NimbleCSVTest do
     """
   end
 
-  NimbleCSV.define(CSVWithUnknownSeparator, separator: [",", ";", "\t"])
+  describe "multiple separators" do
+    NimbleCSV.define(CSVWithUnknownSeparator, separator: [",", ";", "\t"])
 
-  test "parse_string/2 (unknown separator)" do
-    assert CSVWithUnknownSeparator.parse_string("""
-    name,last\tyear
-    john;doe,1986
-    """) == [~w(john doe 1986)]
-  end
-
-  test "parse_stream/2 (unknown separator)" do
-    stream = [
-      "name,last\tyear\n",
-      "john;doe,1986\n"
-    ] |> Stream.map(&String.upcase/1)
-    assert CSVWithUnknownSeparator.parse_stream(stream) |> Enum.to_list == [~w(JOHN DOE 1986)]
-
-    stream = [
-      "name,last\tyear\n",
-      "john;doe,1986\n"
-    ] |> Stream.map(&String.upcase/1)
-    assert CSVWithUnknownSeparator.parse_stream(stream, headers: false) |> Enum.to_list ==
-           [~w(NAME LAST YEAR), ~w(JOHN DOE 1986)]
-
-    stream = CSVWithUnknownSeparator.parse_stream([
-      "name,last\tyear\n",
-      "john;doe,\"1986\n"
-    ] |> Stream.map(&String.upcase/1))
-    assert_raise NimbleCSV.ParseError, ~s(expected escape character " but reached the end of file), fn ->
-      Enum.to_list(stream)
+    test "parse_string/2 (unknown separator)" do
+      assert CSVWithUnknownSeparator.parse_string("""
+      name,last\tyear
+      john;doe,1986
+      """) == [~w(john doe 1986)]
     end
-  end
 
-  test "dump_to_iodata/1 (unknown separator)" do
-    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john", 27]])) == """
-    name,age
-    john,27
-    """
+    test "parse_stream/2 (unknown separator)" do
+      stream = [
+        "name,last\tyear\n",
+        "john;doe,1986\n"
+      ] |> Stream.map(&String.upcase/1)
+      assert CSVWithUnknownSeparator.parse_stream(stream) |> Enum.to_list == [~w(JOHN DOE 1986)]
 
-    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john\ndoe", 27]])) == """
-    name,age
-    "john
-    doe",27
-    """
+      stream = [
+        "name,last\tyear\n",
+        "john;doe,1986\n"
+      ] |> Stream.map(&String.upcase/1)
+      assert CSVWithUnknownSeparator.parse_stream(stream, headers: false) |> Enum.to_list ==
+            [~w(NAME LAST YEAR), ~w(JOHN DOE 1986)]
 
-    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john \"nick\" doe", 27]])) == """
-    name,age
-    "john ""nick"" doe",27
-    """
+      stream = CSVWithUnknownSeparator.parse_stream([
+        "name,last\tyear\n",
+        "john;doe,\"1986\n"
+      ] |> Stream.map(&String.upcase/1))
+      assert_raise NimbleCSV.ParseError, ~s(expected escape character " but reached the end of file), fn ->
+        Enum.to_list(stream)
+      end
+    end
 
-    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["doe, john", 27]])) == """
-    name,age
-    "doe, john",27
-    """
-  end
+    test "dump_to_iodata/1 (unknown separator)" do
+      assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john", 27]])) == """
+      name,age
+      john,27
+      """
 
-  test "dump_to_stream/1 (unknown separator)" do
-    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john", 27]]))) == """
-    name,age
-    john,27
-    """
+      assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john\ndoe", 27]])) == """
+      name,age
+      "john
+      doe",27
+      """
 
-    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john\ndoe", 27]]))) == """
-    name,age
-    "john
-    doe",27
-    """
+      assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john \"nick\" doe", 27]])) == """
+      name,age
+      "john ""nick"" doe",27
+      """
 
-    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john \"nick\" doe", 27]]))) == """
-    name,age
-    "john ""nick"" doe",27
-    """
-  end
+      assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["doe, john", 27]])) == """
+      name,age
+      "doe, john",27
+      """
+    end
 
-  test "parse_string/2 with escape characters (unknown separator)" do
-    assert CSV.parse_string("""
-    name,year
-    "doe, john",1986
-    "jane; mary",1985
-    """) == [["doe, john", "1986"], ["jane; mary", "1985"]]
+    test "dump_to_stream/1 (unknown separator)" do
+      assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john", 27]]))) == """
+      name,age
+      john,27
+      """
+
+      assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john\ndoe", 27]]))) == """
+      name,age
+      "john
+      doe",27
+      """
+
+      assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john \"nick\" doe", 27]]))) == """
+      name,age
+      "john ""nick"" doe",27
+      """
+    end
+
+    test "parse_string/2 with escape characters (unknown separator)" do
+      assert CSV.parse_string("""
+      name,year
+      "doe, john",1986
+      "jane; mary",1985
+      """) == [["doe, john", "1986"], ["jane; mary", "1985"]]
+    end
   end
 
   # TODO: Remove once we depend on Elixir 1.3 and on.

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -277,6 +277,13 @@ defmodule NimbleCSVTest do
     """
   end
 
+  test "parse_string/2 with escape characters (unknown separator)" do
+    assert CSV.parse_string("""
+    name,year
+    "doe, john",1986
+    "jane; mary",1985
+    """) == [["doe, john", "1986"], ["jane; mary", "1985"]]
+  end
 
   # TODO: Remove once we depend on Elixir 1.3 and on.
   Code.ensure_loaded(String)

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -204,6 +204,80 @@ defmodule NimbleCSVTest do
     """
   end
 
+  NimbleCSV.define(CSVWithUnknownSeparator, separator: [",", ";", "\t"])
+
+  test "parse_string/2 (unknown separator)" do
+    assert CSVWithUnknownSeparator.parse_string("""
+    name,last\tyear
+    john;doe,1986
+    """) == [~w(john doe 1986)]
+  end
+
+  test "parse_stream/2 (unknown separator)" do
+    stream = [
+      "name,last\tyear\n",
+      "john;doe,1986\n"
+    ] |> Stream.map(&String.upcase/1)
+    assert CSVWithUnknownSeparator.parse_stream(stream) |> Enum.to_list == [~w(JOHN DOE 1986)]
+
+    stream = [
+      "name,last\tyear\n",
+      "john;doe,1986\n"
+    ] |> Stream.map(&String.upcase/1)
+    assert CSVWithUnknownSeparator.parse_stream(stream, headers: false) |> Enum.to_list ==
+           [~w(NAME LAST YEAR), ~w(JOHN DOE 1986)]
+
+    stream = CSVWithUnknownSeparator.parse_stream([
+      "name,last\tyear\n",
+      "john;doe,\"1986\n"
+    ] |> Stream.map(&String.upcase/1))
+    assert_raise NimbleCSV.ParseError, ~s(expected escape character " but reached the end of file), fn ->
+      Enum.to_list(stream)
+    end
+  end
+
+  test "dump_to_iodata/1 (unknown separator)" do
+    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john", 27]])) == """
+    name,age
+    john,27
+    """
+
+    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john\ndoe", 27]])) == """
+    name,age
+    "john
+    doe",27
+    """
+
+    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john \"nick\" doe", 27]])) == """
+    name,age
+    "john ""nick"" doe",27
+    """
+
+    assert IO.iodata_to_binary(CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["doe, john", 27]])) == """
+    name,age
+    "doe, john",27
+    """
+  end
+
+  test "dump_to_stream/1 (unknown separator)" do
+    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john", 27]]))) == """
+    name,age
+    john,27
+    """
+
+    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john\ndoe", 27]]))) == """
+    name,age
+    "john
+    doe",27
+    """
+
+    assert IO.iodata_to_binary(Enum.to_list(CSVWithUnknownSeparator.dump_to_stream([["name", "age"], ["john \"nick\" doe", 27]]))) == """
+    name,age
+    "john ""nick"" doe",27
+    """
+  end
+
+
   # TODO: Remove once we depend on Elixir 1.3 and on.
   Code.ensure_loaded(String)
 


### PR DESCRIPTION
We use `NimbleCSV` to stream-process CSV files coming from our clients. Unfortunately, it’s nearly impossible to convince clients to use some predefined separator, like commas everywhere. We receive comma-separated CSV files, semicolon-separated CSV files, tab-separated CSV files, sometimes when clients edit these CSV files manually we even receive mixed separators.

This PR basically covers this functionality by accepting an array of separators, without breaking the backward compatibility. It does not have any performance impact when the single separator is given (respective `case` clauses for different separators are generated with macro and the resulting code for the single separator is literally the same as it was before.)

I understand that approach is basically against the generic Elixir ideology, but we cannot afford to parse the file twice, first to guess the separator and then to apply it (possibly producing the new module on the fly.)

I am fine with using my own repo for this functionality, but I believe this might be of some help for others who face the same issue.